### PR TITLE
Get animation working for untitled.glb

### DIFF
--- a/include/skinned_model.hpp
+++ b/include/skinned_model.hpp
@@ -33,6 +33,7 @@ namespace roj
 	struct BoneNode
 	{
 		std::string name;
+		glm::mat4 transform;
 		std::vector<BoneNode> children;
 	};
 

--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -68,22 +68,28 @@ glm::mat4 roj::Animator::interpolateScaling( roj::BoneTransform& boneTransform)
 
 void roj::Animator::calcBoneTransform(BoneNode& node, glm::mat4 offset)
 {
-    auto& boneInfoMap = m_model->boneInfoMap;
-    if (m_currAnim->boneTransforms.find(node.name) != m_currAnim->boneTransforms.end())
+    if (auto it = m_currAnim->boneTransforms.find(node.name); it != m_currAnim->boneTransforms.end())
     {
-        roj::BoneTransform& boneTransform = m_currAnim->boneTransforms.at(node.name);
+        auto& boneTransform = it->second;
         glm::mat4 translation = interpolatePosition(boneTransform);
         glm::mat4 rotation = interpolateRotation(boneTransform);
         glm::mat4 scale = interpolateScaling(boneTransform);
         offset *= translation * rotation * scale;
-        m_boneMatrices[boneInfoMap[node.name].id] = offset * boneInfoMap[node.name].offset;
+    }
+    else {
+        offset *= node.transform;
+    }
+
+    if (auto it = m_model->boneInfoMap.find(node.name); it != m_model->boneInfoMap.end())
+    {
+        auto& boneInfo = it->second;
+        m_boneMatrices[boneInfo.id] = offset * boneInfo.offset;
     }
 
     for (roj::BoneNode& child : node.children)
     {
         calcBoneTransform(child, offset);
     }
-    
 }
 
 roj::Animator::Animator(SkinnedModel& model)

--- a/src/game/scenes/main_scene.cpp
+++ b/src/game/scenes/main_scene.cpp
@@ -7,17 +7,17 @@ namespace mainscene
 	{
 		roj::ModelLoader<roj::SkinnedMesh> modelLoader;
 		
-		modelLoader.load("res/assets/models/viewmodel/scene.gltf");
+		modelLoader.load("res/assets/models/viewmodel/untitled.glb");
 		resources.skinnedModels.emplace_back(std::move(modelLoader.get()));
-		roj::Animator animator{ resources.skinnedModels[0] };
-		animator.set("allanims");
 		resources.shaderObjects["basic"].link("res/shaders/vs_basic.glsl", "res/shaders/fs_basic.glsl");
 		
 		auto entity = scene.entities.create();
-		scene.entities.emplace<game::Transform>(entity, game::Transform{});
-		scene.entities.emplace<game::Renderable>(entity, game::Renderable{ uint32_t(resources.skinnedModels.size()-1), "basic"});
-		scene.entities.emplace<roj::Animator>(entity, animator);
-		scene.camera = { glm::vec3(0.0) };
+
+		scene.entities.emplace<game::Transform>(entity);
+		scene.entities.emplace<game::Renderable>(entity, (uint32_t)resources.skinnedModels.size()-1, "basic");
+		scene.entities.emplace<roj::Animator>(entity, resources.skinnedModels[0]).set("Action.001");
+
+		scene.camera = { { -235.0f, 244.0f, 181.0f }, {0.0f, 1.0f, 0.0f}, -34.1f, -27.1f };
 	}
 
 	void update(roj::Scene& scene)
@@ -45,7 +45,7 @@ namespace mainscene
 			shader.uniform3f("viewPos", viewPos);
 			shader.uniformMat4("view", viewMatrix);
 			shader.uniformMat4("model", glm::scale(modelMatrix, glm::vec3(transform.scale)));
-			shader.uniformMat4("projection", glm::perspective(glm::radians(45.f), (float)1280 / (float)720, 0.1f, 100.0f));
+			shader.uniformMat4("projection", glm::perspective(glm::radians(45.f), (float)1280 / (float)720, 0.1f, 1000.0f));
 			auto transforms = animator.getBoneMatrices();
 			for (int i = 0; i < transforms.size(); ++i)
 				shader.uniformMat4("finalBonesMatrices[" + std::to_string(i) + "]", transforms[i]);
@@ -81,8 +81,8 @@ namespace mainscene
 
 	void cursorCallback(roj::Scene& scene, float xpos_p, float ypos_p)
 	{
-		static float lastX = 0.0f;
-		static float lastY = 0.0f;
+		static float lastX = xpos_p;
+		static float lastY = ypos_p;
 
 		float xoffset = xpos_p - lastX;
 		float yoffset = lastY - ypos_p; // reversed since y-coordinates go from bottom to top

--- a/src/skinned_model.cpp
+++ b/src/skinned_model.cpp
@@ -23,12 +23,12 @@ static void extractBoneData(std::vector<roj::SkinnedMesh::Vertex>& vertices, aiM
         for (int j = 0; j < mesh->mBones[i]->mNumWeights; ++j)
         {
             auto& vertex = vertices[weights[j].mVertexId];
-            for (int i = 0; i < MAX_BONE_INFLUENCE; ++i)
+            for (int k = 0; k < MAX_BONE_INFLUENCE; ++k)
             {
-                if (vertex.boneIds[i] == -1)
+                if (vertex.weights[k] == 0.0f)
                 {
-                    vertex.weights[i] = weights[j].mWeight;
-                    vertex.boneIds[i] = boneId;
+                    vertex.weights[k] = weights[j].mWeight;
+                    vertex.boneIds[k] = boneId;
                     break;
                 }
             }
@@ -38,6 +38,7 @@ static void extractBoneData(std::vector<roj::SkinnedMesh::Vertex>& vertices, aiM
 static void extractBoneNode(roj::BoneNode& bone, aiNode* src)
 {
     bone.name = src->mName.data;
+    bone.transform = toGlmMat4(src->mTransformation);
     for (unsigned int i = 0; i < src->mNumChildren; i++)
     {
         roj::BoneNode node;
@@ -196,7 +197,7 @@ std::vector<SkinnedMesh::Vertex> ModelLoader<SkinnedMesh>::getMeshVertices(aiMes
         }
         else
             vertex.texCoords = glm::vec2(0.0f, 0.0f);
-        std::fill(vertex.boneIds, vertex.boneIds + MAX_BONE_INFLUENCE, -1);
+        std::fill(vertex.boneIds, vertex.boneIds + MAX_BONE_INFLUENCE, 0);
         std::fill(vertex.weights, vertex.weights + MAX_BONE_INFLUENCE, 0.0f);
         vertices.push_back(vertex);
     }


### PR DESCRIPTION
- Unused vertex bone weight slots should not use -1 for index, as this causes UB in shader
- When traversing bone hierarchy to compute bone transforms, any bones that are not animated must be set to skeleton rest pose (and these transforms must also propagate down to the child bones)

Other:
- Set initial camera position so the untitled model can be seen
- Increase camera far plane so that model is not clipped
- Initialise lastX and lastY in cursorCallback so that first move of the mouse isnt a giant leap